### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,53 @@
 
 ## Descripción general
 En el presente proyecto se definen contratos mínimos para los endpoints /health y /metrics, y se construye una suite de pruebas automatizadas con Bats siguiendo el ciclo RGR. Se utiliza curl, parsers simples y Make para automatizar la ejecución y validación, incluyendo casos negativos como estructuras inválidas o latencia excesiva, y se generan reportes de cumplimiento en la carpeta out/.
+
+
+## Instrucciones de uso
+
+1. **Instalar dependencias**  
+   Se requiere [bats-core](https://github.com/bats-core/bats-core).
+
+   ```bash
+   # Ubuntu/Debian
+   sudo apt-get update && sudo apt-get install -y bats
+   ```
+
+2. **Ejecutar pruebas**
+   Las pruebas están en `tests/health_metrics.bats`.
+
+   ```bash
+   bats tests/health_metrics.bats
+   ```
+
+---
+
+## Variables de entorno
+
+| Variable    | Efecto                                                                    |
+| ----------- | ------------------------------------------------------------------------- |
+| `BASE_URL`  | URL base del servicio a testear. Por defecto `http://127.0.0.1:8080`.     |
+| `BUDGET_MS` | Límite máximo de latencia (en milisegundos) para `/health`. Default: 200. |
+
+Ejemplo de uso:
+
+```bash
+BASE_URL=http://localhost:5000 BUDGET_MS=300 bats tests/health_metrics.bats
+```
+
+---
+
+## Contrato de salidas
+
+### `/health`
+
+* **200 OK**
+* `Content-Type: application/json`
+* **Body mínimo (JSON):**
+* Latencia ≤ `BUDGET_MS`.
+
+### `/metrics`
+
+* **200 OK**
+* `Content-Type: text/plain` (se acepta `text/plain; version=0.0.4`)
+* **Cuerpo mínimo:**

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -1,0 +1,86 @@
+# Bitácora — Sprint 1
+
+## Contratos `/health` y `/metrics`
+
+### 1) Desarrollo de contrato `/health` y `/metrics` junto a 
+
+Durante el Sprint 1 se definieron los **contratos formales** de las salidas `/health` y `/metrics`, y se implementaron pruebas **Bats** deliberadamente en **estado rojo** (RGR: Red → Green → Refactor) con **casos positivos mínimos** y **negativos simples**. Estas pruebas fallan deliberadamente por no tener el backend desarrollado aún, lo cual es de esperarse.
+
+### 2) Alcance del Sprint 1
+
+* Definir contratos formales: **status esperado, forma de payload y campos mínimos** para `/health` y `/metrics`.
+* Crear pruebas **Bats** para `/health` y `/metrics` que **fallen inicialmente**:
+  * Casos positivos mínimos (código 200, content-type correcto, presencia de campos/métricas requeridas).
+  * Casos negativos simples (ausencia de métricas/campos rompe el contrato).
+* Entregables:
+  * `docs/contrato-salidas.md` con criterios verificables y **referencias de validación vía curl y toolkit de texto**.
+  * `tests/health_metrics.bats` (estado **rojo**).
+
+### 3) Entregables producidos
+
+* `docs/contrato-salidas.md`
+  Contiene los contratos verificables de `/health` (JSON) y `/metrics` (Prometheus text format), con ejemplos de validación mediante `curl`, `grep`, `awk`.
+* `tests/health_metrics.bats`
+  Suite de pruebas Bats (AAA + RGR) para `/health` y `/metrics`, incluyendo un negativo simple para métricas mínimas.
+
+### 4) Criterios de aceptación (contratos resumidos)
+
+**GET `/health`**
+
+* **200 OK**
+* **Content-Type:** `application/json`
+* **Body mínimo (JSON):**
+* **Latencia:** `time_total` de `curl` ≤ **200 ms** (configurable vía `BUDGET_MS`).
+
+**GET `/metrics`** (formato Prometheus – texto)
+
+* **200 OK**
+* **Content-Type:** `text/plain` (se acepta `text/plain; version=0.0.4`)
+
+### 5) Actividades realizadas
+
+1. Redacción de **contratos verificables** y documentados con comandos reproducibles (curl + toolkit de texto).
+2. Implementación de **pruebas Bats**:
+
+   * **Positivas mínimas**: validan 200/Content-Type correcto y contenido requerido.
+   * **Negativa simple**: falla si las métricas mínimas están ausentes.
+3. Parametrización con variables `BASE_URL` y `BUDGET_MS` para ejecutar tests contra distintos entornos.
+4. Guía de ejecución local (instalación de Bats y comando `bats tests/health_metrics.bats`).
+
+### 6) Evidencias de ejecución (Sprint 1)
+
+Dado que el servicio aún **no** está implementado, se obtuvieron fallos esperados:
+
+* `GET /health` → **falla** por ausencia de servicio o por no cumplir Content-Type/JSON mínimo.
+* `GET /metrics` → **falla** por Content-Type incorrecto o ausencia de métricas mínimas.
+
+Salida:
+
+```
+ ✗ GET /health -> 200 y Content-Type application/json (contrato mínimo)
+   (in test file tests/health_metric.bats, line 26)
+     `[ "$code" -eq 200 ]' failed with status 2
+
+     ...
+
+ ✗ GET /health -> cuerpo JSON con status="ok" y latencia <= BUDGET_MS
+   (in test file tests/health_metric.bats, line 39)
+     `[ "$code" -eq 200 ]' failed with status 2
+
+     ...
+
+ ✗ GET /metrics -> 200, text/plain y métricas mínimas (uptime + requests a /health)
+   (in test file tests/health_metric.bats, line 57)
+     `[ "${output}" -eq 200 ]' failed with status 2
+
+     ...
+```
+
+
+### 7) Decisiones de diseño
+
+* **/metrics** seguirá el **formato Prometheus** (texto plano) por ser un formato estandarizado.
+* Se exige **latencia** máxima configurable (`BUDGET_MS`, por defecto 200 ms) en `/health`, puesto que se espera una respuesta rápida en este endpoint.
+* Contratos escritos con **criterios observables** desde CLI (sin frameworks adicionales).
+* **Tolerancia** de parámetros en `Content-Type` de `/metrics` (compatibilidad con `version=0.0.4`).
+

--- a/docs/contrato-salida.md
+++ b/docs/contrato-salida.md
@@ -1,0 +1,74 @@
+# Contrato de salidas: /health y /metrics
+
+Este documento define contratos **verificables con herramientas de línea de comando** y establece los **campos mínimos** esperados.
+
+## Variables de entorno (por ahora, para pruebas)
+- `BASE_URL` (Por defecto: `http://127.0.0.1:8080`)
+- `BUDGET_MS` (límite de latencia total por request). Por defecto: `200` ms para /health.
+
+---
+
+## Contrato: `GET /health`
+
+### Requisitos mínimos
+1. **Código**: `200 OK`.
+2. **Header**: `Content-Type: application/json`
+3. **Body (JSON)** con **campos mínimos**:
+   - `status`: string **"ok"**
+   - `time`: timestamp ISO-8601 (por ejemplo, `2025-09-29T12:34:56Z`)
+4. **Latencia**: tiempo total (`time_total` de curl) **≤ `BUDGET_MS`** (200 ms por defecto).
+
+### Criterios de validación
+```bash
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+BUDGET_MS="${BUDGET_MS:-200}"
+
+# Descargar respuesta, headers y tiempos
+tmp_h=$(mktemp); tmp_b=$(mktemp)
+read -r code ttotal < <(curl -sS -D "$tmp_h" -o "$tmp_b" -w "%{http_code} %{time_total}" "$BASE_URL/health")
+
+# Verificaciones:
+test "$code" -eq 200
+grep -iq '^content-type: *application/json' "$tmp_h"
+grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' "$tmp_b"
+
+# latencia <= presupuesto
+awk -v t="$ttotal" -v ms="$BUDGET_MS" 'BEGIN{exit !(t*1000 <= ms)}'
+```
+
+---
+
+## Contrato: `GET /metrics`
+
+Se adopta el formato de exposición de Prometheus (texto plano) mínimo.
+
+### Requisitos mínimos
+
+1. **Código**: `200 OK`.
+2. **Header**: `Content-Type: text/plain` (se tolera `text/plain; version=0.0.4`).
+3. **Cuerpo**: Debe incluir, al menos:
+   * Una métrica de **uptime**: `process_uptime_seconds` con un valor numérico.
+   * Un contador de requests a `/health`: `http_requests_total{path="/health"}` con valor numérico.
+
+### Criterios de validación
+
+```bash
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+tmp_h=$(mktemp); tmp_b=$(mktemp)
+read -r code _ < <(curl -sS -D "$tmp_h" -o "$tmp_b" -w "%{http_code} %{content_type}\n" "$BASE_URL/metrics")
+
+test "$code" -eq 200
+grep -iq '^content-type: *text/plain' "$tmp_h"
+
+# Debe existir una línea con la métrica de uptime y otra con el contador de /health
+grep -E '^process_uptime_seconds([[:space:]]|{).* [0-9.eE+-]+$' "$tmp_b"
+grep -E '^http_requests_total\{.*path="/health".*\} [0-9.eE+-]+$' "$tmp_b"
+```
+
+---
+
+## Fallos esperados (negativos simples) que invalidan el contrato
+
+- `/health` sin `Content-Type: application/json`
+- `/health` sin `"status":"ok"` o con tiempo total > `BUDGET_MS`.
+- `/metrics` sin `text/plain`, o que no incluya ambas métricas mínimas anteriores.

--- a/tests/health_metric.bats
+++ b/tests/health_metric.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+setup() {
+  set -euo pipefail
+  BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+  BUDGET_MS="${BUDGET_MS:-200}"
+
+  TMP_H="$(mktemp)"
+  TMP_B="$(mktemp)"
+}
+
+teardown() {
+  rm -f "${TMP_H:-}" "${TMP_B:-}" || true
+}
+
+@test "GET /health -> 200 y Content-Type application/json (contrato mínimo)" {
+  # Arrange: URL objetivo en BASE_URL
+  # Act: ejecutar curl y capturar headers/body/código
+  run bash -c '
+    read -r code ttotal < <(curl -sS -D "$TMP_H" -o "$TMP_B" -w "%{http_code} %{time_total}" "'"$BASE_URL"'/health");
+    echo "$code $ttotal"
+  '
+  # Assert: código 200 y content-type JSON
+  [ "$status" -eq 0 ]  # curl debe haber retornado ok
+  read -r code ttotal <<<"${output}"
+  [ "$code" -eq 200 ]
+  run grep -iq "^content-type: *application/json" "$TMP_H"
+  [ "$status" -eq 0 ]
+}
+
+@test "GET /health -> cuerpo JSON con status=\"ok\" y latencia <= BUDGET_MS" {
+  # Arrange/Act
+  run bash -c '
+    read -r code ttotal < <(curl -sS -D "$TMP_H" -o "$TMP_B" -w "%{http_code} %{time_total}" "'"$BASE_URL"'/health");
+    echo "$code $ttotal"
+  '
+  [ "$status" -eq 0 ]
+  read -r code ttotal <<<"${output}"
+  [ "$code" -eq 200 ]
+
+  # Assert: contiene "status":"ok"
+  run grep -q "\"status\"[[:space:]]*:[[:space:]]*\"ok\"" "$TMP_B"
+  [ "$status" -eq 0 ]
+
+  # Assert: latencia (s) * 1000 <= BUDGET_MS
+  run awk -v t="$ttotal" -v ms="$BUDGET_MS" "BEGIN{exit !(t*1000 <= ms)}"
+  [ "$status" -eq 0 ]
+}
+
+@test "GET /metrics -> 200, text/plain y métricas mínimas (uptime + requests a /health)" {
+  # Arrange/Act
+  run bash -c '
+    read -r code _ < <(curl -sS -D "$TMP_H" -o "$TMP_B" -w "%{http_code} %{content_type}\n" "'"$BASE_URL"'/metrics");
+    echo "$code"
+  '
+  [ "$status" -eq 0 ]
+  [ "${output}" -eq 200 ]
+
+  # Assert: Content-Type text/plain (se acepta con parámetros)
+  run grep -iq "^content-type: *text/plain" "$TMP_H"
+  [ "$status" -eq 0 ]
+
+  # Assert: métricas mínimas con valor numérico
+  run grep -E "^process_uptime_seconds([[:space:]]|{).* [0-9.eE+-]+$" "$TMP_B"
+  [ "$status" -eq 0 ]
+  run grep -E "^http_requests_total\{.*path=\"/health\".*\} [0-9.eE+-]+$" "$TMP_B"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Creación del servicio requerido

## Objetivo
- Levantar un servicio accesible pero con respuestas dummy, de manera que las pruebas bats se mantengan en rojo (RGR: Red → Green → Refactor).

## Cambios introducidos

- Nuevo archivo src/service.py:

   - Endpoint /health: responde 200 OK, JSON {"status":"dummy","uptime":"0s"}.

   - Endpoint /metrics: responde 200 OK, text/plain con métricas ficticias (requests_total 0, latency_ms_p50 0).

   - Rutas no definidas: 404 Not Found, JSON {"error":"not found"}.

- Bitácora de Sprint 1 (docs/bitacora-sprint-1.md):

   - Pasos de instalación y ejecución manual con Flask.

   - Evidencias de pruebas manuales con curl.

   - Explicación de por qué las pruebas Bats permanecen en estado rojo.

- [X] src/service.py con fixture mínimo en Flask.

- [X]docs/bitacora-sprint-1.md con comandos y evidencias.
