### PR TITLE
S3 - Refactor y logging del servicio

### DIFF
--- a/docs/bitacora-sprint-3.md
+++ b/docs/bitacora-sprint-3.md
@@ -1,0 +1,78 @@
+# Bitácora — Sprint 3
+
+## Pruebas bats
+
+### 1) Objetivos
+- Refactor de pruebas: limpieza, nombres claros, helpers reutilizables.
+- Añadir test de **idempotencia**: dos corridas seguidas sin “trabajo extra” (payload estable; contador de métricas aumenta solo lo esperado).
+- Mantener AAA/RGR y evidencias legibles.
+
+### 2) Cambios principales
+
+-`src/service.py`
+  - **Logging** a `out/service.log` (configurable con `LOG_PATH`).
+  - **Nueva métrica global** `http_requests_total` (todas las requests) además de `http_requests_total{path="/health"}`.
+  - **Hook** `@before_request` para contar cada request entrante.
+  - **Concurrencia**: contadores protegidos con `threading.Lock`.
+  - **Robustez**: manejo de errores con `try/except` en `/health` y `/metrics`, con `logging.exception`.
+  - **Sin cambios de contrato**: `/health` sigue respondiendo `{"status":"ok"}` y `/metrics` mantiene `process_uptime_seconds` y el contador de `/health`.
+
+
+
+- `tests/health_metrics.bats`:
+  - Helpers: `curl_json`, `curl_plain`, `metric_value`, `normalize_health_body`, `save_evidence`.
+  - Positivos: `/health` (200/json/ok/latencia), `/metrics` (text/plain + mínimas).
+  - Negativos estables: estructura inválida en `/metrics`, `status` incorrecto en `/health`, detector de latencia.
+  - **Nuevo**: test `idempotencia-health-2x`.
+
+### 3) Idempotencia
+- **Payload**: se enmascara el campo volátil `"time"` y se comparan hashes SHA-256 de los cuerpos normalizados en dos llamadas consecutivas a `/health`.
+- **Métrica**: se lee `http_requests_total{path="/health"}` antes y después; se exige `delta == 2`.
+
+### 4) Evidencias
+Tras ejecutar:
+```bash
+bats tests/health_metrics.bats
+```
+
+Se generan directorios `out/` con:
+
+* `.../idempotencia-health-2x/headers.txt`
+* `.../idempotencia-health-2x/body_excerpt.txt`
+* `.../idempotencia-health-2x/meta.txt`
+
+**Ejemplo de `meta.txt`:**
+
+```
+base_url=http://127.0.0.1:8080
+budget_ms=200
+http_code=200
+time_total_s=0.041,0.039
+content_type=Content-Type: application/json
+```
+
+### 5) Cómo interpretar
+
+* **Idempotente**: si `norm1 == norm2` y el delta del contador es `2`, la operación GET no introduce trabajo extra ni efectos colaterales inesperados.
+* Si falla:
+  * Revisa `headers.txt` y `body_excerpt.txt`.
+  * Verifica que `/metrics` reporte `http_requests_total{path="/health"}`.
+
+### 4) Ejecución rápida
+
+> Requisitos: Python 3, `bats` instalado, y puerto `8080` libre.
+
+**1) Preparar entorno**
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+```
+
+```bash
+# Valores por defecto:
+# BASE_URL=http://127.0.0.1:8080
+# BUDGET_MS=200
+
+bats tests/health_metrics.bats
+```

--- a/src/service.py
+++ b/src/service.py
@@ -2,42 +2,70 @@
 import os
 import time
 import threading
+import logging
 from flask import Flask, jsonify, Response, request
 
 app = Flask(__name__)
 
-PORT = int(os.getenv("PORT", "8080")) 
+# --- Configuración ---
+PORT = int(os.getenv("PORT", "8080"))
 BIND_ADDR = os.getenv("BIND_ADDR", "127.0.0.1")
+LOG_PATH = os.getenv("LOG_PATH", "out/service.log")
 
+# --- Logging básico ---
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+logging.basicConfig(
+    filename=LOG_PATH,
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+# --- Métricas internas ---
 START_TIME = time.time()
 _health_requests = 0
+_total_requests = 0
 _lock = threading.Lock()
 
 def inc_health():
     global _health_requests
     with _lock:
         _health_requests += 1
+        logging.info("/health called (%d total)", _health_requests)
 
-def get_health_requests():
+def inc_total():
+    global _total_requests
     with _lock:
-        return _health_requests
+        _total_requests += 1
 
 def uptime_seconds():
     return max(0.0, time.time() - START_TIME)
 
+@app.before_request
+def before_request():
+    inc_total()
+
 @app.get("/health")
 def health():
-    inc_health()
-    return jsonify(status="ok"), 200, {"Content-Type": "application/json"}
+    try:
+        inc_health()
+        return jsonify(status="ok"), 200, {"Content-Type": "application/json"}
+    except Exception as e:
+        logging.exception("Error en /health: %s", e)
+        return jsonify(status="error", message=str(e)), 500
 
 @app.get("/metrics")
 def metrics():
-    lines = []
-    lines.append(f"process_uptime_seconds {uptime_seconds():.6f}")
-    lines.append(f'http_requests_total{{path="/health"}} {get_health_requests()}')
-    body = "\n".join(lines) + "\n"
-
-    return Response(body, status=200, mimetype="text/plain")
+    try:
+        lines = [
+            f"process_uptime_seconds {uptime_seconds():.6f}",
+            f'http_requests_total{{path="/health"}} {_health_requests}',
+            f"http_requests_total {_total_requests}",
+        ]
+        body = "\n".join(lines) + "\n"
+        return Response(body, status=200, mimetype="text/plain")
+    except Exception as e:
+        logging.exception("Error en /metrics: %s", e)
+        return Response(f"# error: {e}\n", status=500, mimetype="text/plain")
 
 @app.get("/", defaults={"path": ""})
 @app.get("/<path:path>")
@@ -45,4 +73,5 @@ def not_found(path):
     return jsonify(error="not found"), 404, {"Content-Type": "application/json"}
 
 if __name__ == "__main__":
+    logging.info("Servicio iniciado en %s:%s", BIND_ADDR, PORT)
     app.run(host=BIND_ADDR, port=PORT, debug=False, use_reloader=False)


### PR DESCRIPTION
# PR: Sprint 3 – Refactor y logging del servicio Flask (/health y /metrics)

## Objetivo

Este PR cumple con el alcance del **Sprint 3** del Proyecto 7 para la **Persona C (Fixture Servicio)**:

* Refactorizar el servicio Flask implementado en Sprint 2 para hacerlo más **robusto, trazable y listo para integración continua (CI)**.  
* Añadir logging, manejo de errores y métricas extendidas sin romper los contratos formales definidos en `/health` y `/metrics`.  

---

## Cambios incluidos

### Servicio (`src/service.py`)
- **Logging básico** a `out/service.log` (configurable vía `LOG_PATH`).
- **Nueva métrica global**: `http_requests_total` (todas las requests) además de `http_requests_total{path="/health"}`.
- **Hook `@before_request`** para contar cada request recibida.
- **Concurrencia segura** con `threading.Lock` en contadores.
- **Manejo de errores** en `/health` y `/metrics` con `try/except` y `logging.exception`, devolviendo `500` si ocurre un fallo.
- **Contratos mantenidos**:
  - `/health`: `200 OK`, `application/json`, body `{"status":"ok"}`.
  - `/metrics`: `200 OK`, `text/plain`, incluye `process_uptime_seconds` y `http_requests_total{path="/health"}`.

 [X] Servicio Flask refactorizado con logging y manejo de errores.

 [X] Métrica global http_requests_total agregada.

 [X] Makefile con targets run, test, clean.

 [X] Todas las pruebas en verde y negativos en skip.

 [X] Bitácora Sprint 3 actualizada (docs/bitacora-sprint-3.md).

