### PR TITLE
PR Final - Sprint 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PY          ?= $(VENV)/bin/python
 
 APP         ?= $(SRCDIR)/service.py
 BIND_ADDR   ?= 127.0.0.1
-PORT        ?= 8000
+PORT        ?= 8080
 BUDGET_MS   ?= 150
 
 REL         ?= 0.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,114 @@
-#Makefile
-
 SHELL := bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
 
-OUTDIR ?= out
-DISTDIR ?= dist
-SRCDIR ?= src
-TESTDIR ?= tests
-APP ?= $(SRCDIR)/service.py
-PORT ?= 8000
-BIND_ADDR ?= 127.0.0.1
-BUDGET_MS ?= 150
+SRCDIR      ?= src
+TESTDIR     ?= tests
+DOCSDIR     ?= docs
+OUTDIR      ?= out
+DISTDIR     ?= dist
+VENV        ?= .venv
+PYTHON      ?= python3
+PIP         ?= $(VENV)/bin/pip
+PY          ?= $(VENV)/bin/python
 
-TEST_FILE ?= $(TESTDIR)/health_metric.bats
-CONTRACT_DOC ?= docs/contrato-salida.md
+APP         ?= $(SRCDIR)/service.py
+BIND_ADDR   ?= 127.0.0.1
+PORT        ?= 8000
+BUDGET_MS   ?= 150
 
-VENV ?= .venv
-PYTHON ?= python3
-PIP ?= $(VENV)/bin/pip
-PY ?= $(VENV)/bin/python
+REL         ?= 0.3.0
 
-TOOLS = curl bats jq bash
+REQFILE     := requirements.txt
+SOURCES     := $(shell find $(SRCDIR) -type f -name '*.py' 2>/dev/null)
+TESTS       := $(shell find $(TESTDIR) -type f -name '*.bats' 2>/dev/null)
+DOCS        := $(shell find $(DOCSDIR) -type f \( -name '.md' -o -name '.txt' \) 2>/dev/null)
+ROOTFILES   := Makefile $(REQFILE)
+INPUTS      := $(ROOTFILES) $(SOURCES) $(TESTS) $(DOCS)
+
+STAMP_BUILD := $(OUTDIR)/.built.stamp
+STAMP_TEST  := $(OUTDIR)/.tested.stamp
+MANIFEST    := $(OUTDIR)/manifest.txt
+CHECKSUMS   := $(OUTDIR)/checksums.txt
+PIDFILE     := $(OUTDIR)/app.pid
+APPLOG      := $(OUTDIR)/app.log
+
+DIST_TAR    := $(DISTDIR)/proyecto-$(REL).tar.gz
 
 .DEFAULT_GOAL := help
-.PHONY: tools build run test pack clean help all _wait_port _kill_app
 
-all: tools build test 
-	@echo "[all] Pipeline básico OK"
+.PHONY: all tools build run test pack clean help verify-idempotency _wait_port _kill_app _venv _checksums _manifest
+
+all: tools build test
+	@echo "[all] Pipeline básico completado (tools→build→test)."
+
 tools:
-	@echo "Verificando herramientas"
-	@for t in $(TOOLS); do \
-		if ! command -v $$t >/dev/null 2>&1; then \
-			echo "Falta herramienta requerida: $$t"; exit 1; \
-		else \
-			echo "OK: $$t"; \
-		fi \
-	done
-	command -v $(PYTHON) >/dev/null || { echo "python3 no encontrado"; exit 1; }
+	@echo "[tools] Verificando herramientas..."
+	command -v bash >/dev/null
+	command -v curl >/dev/null
+	command -v jq >/dev/null
+	command -v bats >/dev/null
+	command -v $(PYTHON) >/dev/null
+	@echo "[tools] OK"
 
+build: $(STAMP_BUILD)
+	@echo "[build] OK (caché incremental)."
 
-build: $(OUTDIR) $(DISTDIR)
-	@echo "[build] Preparando dependencias"
-	if [[ -f requirements.txt ]]; then
-		$(PYTHON) -m venv $(VENV)
-		source $(VENV)/bin/activate
-		$(PIP) install --upgrade pip >/dev/null
-		$(PIP) install -r requirements.txt
+_venv:
+	@echo "[venv] Preparando entorno virtual (si aplica)..."
+	if [[ -f $(REQFILE) ]]; then \
+		$(PYTHON) -m venv $(VENV); \
+		source $(VENV)/bin/activate; \
+		$(PIP) install --upgrade pip >/dev/null; \
+		$(PIP) install -r $(REQFILE); \
+	else \
+		echo "[venv] No hay requirements.txt; se usará python del sistema"; \
 	fi
-	@echo "[build] Listo"
 
-$(OUTDIR):
-	mkdir -p $(OUTDIR)
+$(OUTDIR) $(DISTDIR):
+	mkdir -p $@
 
-$(DISTDIR):
-	mkdir -p $(DISTDIR)
+# Checksums de entradas para decidir si hay trabajo
+_checksums: | $(OUTDIR)
+	@echo "[cache] Generando checksums..."
+	{ \
+		for f in $(INPUTS); do \
+			if [[ -f $$f ]]; then sha256sum "$$f"; fi; \
+		done; \
+	} | sort > $(CHECKSUMS).new
+	if [[ -f $(CHECKSUMS) ]]; then \
+		if cmp -s $(CHECKSUMS).new $(CHECKSUMS); then \
+			echo "[cache] Checksums sin cambios"; \
+			rm -f $(CHECKSUMS).new; \
+		else \
+			echo "[cache] Cambios detectados en entradas"; \
+			mv $(CHECKSUMS).new $(CHECKSUMS); \
+		fi; \
+	else \
+		mv $(CHECKSUMS).new $(CHECKSUMS); \
+	fi
+
+_manifest: | $(OUTDIR)
+	@echo "[manifest] Escribiendo manifest..."
+	{ \
+		echo "REL=$(REL)"; \
+		date -u +"BUILD_UTC=%Y-%m-%dT%H:%M:%SZ"; \
+		echo "BIND_ADDR=$(BIND_ADDR)"; \
+		echo "PORT=$(PORT)"; \
+		echo "BUDGET_MS=$(BUDGET_MS)"; \
+		git rev-parse --short HEAD 2>/dev/null | sed 's/^/GIT_HEAD=/'; \
+	} > $(MANIFEST)
+
+$(STAMP_BUILD): | $(OUTDIR) $(DISTDIR)
+	@echo "[build] Iniciando..."
+	@$(MAKE) _checksums
+	@$(MAKE) _manifest
+	@$(MAKE) _venv
+	@touch $(STAMP_BUILD)
 
 run: build
 	@echo "[run] Iniciando servicio en http://$(BIND_ADDR):$(PORT)"
-	@echo "[run] Ctrl+C para detener"
 	ENV=dev BIND_ADDR=$(BIND_ADDR) PORT=$(PORT) $(PY) $(APP)
 
 _wait_port:
@@ -71,67 +121,91 @@ _wait_port:
 	done; \
 	echo "[wait] Timeout esperando servicio"; exit 1
 
-
 _kill_app:
-	@if [[ -f $(OUTDIR)/app.pid ]]; then \
-		PID=$$(cat $(OUTDIR)/app.pid); \
+	@if [[ -f $(PIDFILE) ]]; then \
+		PID=$$(cat $(PIDFILE)); \
 		if ps -p $$PID >/dev/null 2>&1; then \
 			echo "[kill] Deteniendo $$PID"; \
 			kill $$PID; \
 			wait $$PID 2>/dev/null || true; \
 		fi; \
-		rm -f $(OUTDIR)/app.pid; \
+		rm -f $(PIDFILE); \
 	fi
 
+test: $(STAMP_TEST)
+	@echo "[test] OK (evidencias en $(OUTDIR))."
 
-test: build
-	@echo "[test] Lanzando servicio en background"
-	ENV=test BIND_ADDR=$(BIND_ADDR) PORT=$(PORT) $(PY) $(APP) >$(OUTDIR)/app.log 2>&1 & echo $$! > $(OUTDIR)/app.pid
+$(STAMP_TEST): build
+	@echo "[test] Lanzando servicio en background..."
+	ENV=test BIND_ADDR=$(BIND_ADDR) PORT=$(PORT) $(PY) $(APP) >$(APPLOG) 2>&1 & echo $$! > $(PIDFILE)
 	@$(MAKE) _wait_port
-	@echo "[test] Ejecutando Bats"
-	@set +e
-	BUDGET_MS=$(BUDGET_MS) PORT=$(PORT) BIND_ADDR=$(BIND_ADDR) bats -t $(TEST_FILE) | tee $(OUTDIR)/bats.tap
+	@echo "[test] Ejecutando Bats..."
+	# Ejecuta todos los .bats
+	set +e
+	BUDGET_MS=$(BUDGET_MS) PORT=$(PORT) BIND_ADDR=$(BIND_ADDR) bats -t $(TESTDIR) | tee $(OUTDIR)/bats.tap
 	STATUS=$$?
 	set -e
-	@echo "[test] Guardando evidencia de /health y /metrics"
+	@echo "[test] Guardando evidencia curl..."
 	{ \
-		echo "# curl /health"; \
+		echo "# GET /health"; \
 		curl -sS -w "\n%{http_code} %{time_total}\n" "http://$(BIND_ADDR):$(PORT)/health" -o $(OUTDIR)/health.json; \
-		echo "# curl /metrics"; \
+		echo ""; \
+		echo "# GET /metrics"; \
 		curl -sS -w "\n%{http_code} %{time_total}\n" "http://$(BIND_ADDR):$(PORT)/metrics" -o $(OUTDIR)/metrics.txt; \
 	} > $(OUTDIR)/curl-evidence.txt || true
 	@$(MAKE) _kill_app
-	@if [[ $$STATUS -ne 0 ]]; then \
+	if [[ $$STATUS -ne 0 ]]; then \
 		echo "[test] Fallos en pruebas (ver $(OUTDIR)/bats.tap)"; exit $$STATUS; \
-	else \
-		echo "[test] Todas las pruebas OK"; \
 	fi
+	@touch $(STAMP_TEST)
 
 pack: build
-	@echo "[pack] Generando artefacto reproducible"
-	REL ?= 0.1.0
-	SOURCE_DATE_EPOCH=$$(date -u +%s); export SOURCE_DATE_EPOCH; \
+	@echo "[pack] Generando artefacto reproducible..."
+	# Para reproducibilidad, fija la fecha a la última modificación entre inputs
+	SOURCE_DATE_EPOCH=$$( \
+		{ for f in $(INPUTS); do if [[ -f $$f ]]; then date -r $$f +%s; fi; done; } | sort -n | tail -1 \
+	); \
+	if [[ -z "$$SOURCE_DATE_EPOCH" ]]; then SOURCE_DATE_EPOCH=$$(date -u +%s); fi; \
+	export SOURCE_DATE_EPOCH; \
 	tar --sort=name --owner=0 --group=0 --numeric-owner \
 	    --mtime="@$${SOURCE_DATE_EPOCH}" \
-	    -czf "$(DISTDIR)/proyecto-$(REL).tar.gz" \
-	    --exclude-vcs \
-	    $(SRCDIR) $(TESTDIR) docs Makefile requirements.txt || { echo "[pack] fallo"; exit 1; }
-	@echo "[pack] Artefacto: $(DISTDIR)/proyecto-$(REL).tar.gz"
+	    --transform 's,^,$(notdir $(CURDIR))/,S' \
+	    -czf "$(DIST_TAR)" \
+	    --exclude-vcs --exclude="$(VENV)" --exclude="$(OUTDIR)" --exclude="$(DISTDIR)" \
+	    --exclude='_pycache_' --exclude='*.pyc' --exclude='.DS_Store' \
+	    $(SRCDIR) $(TESTDIR) $(DOCSDIR) Makefile $(REQFILE) 2>/dev/null || { echo "[pack] fallo"; exit 1; }
+	@echo "[pack] Artefacto: $(DIST_TAR)"
+
+
+verify-idempotency: build test
+	@echo "[idempotency] Verificando que una segunda ejecución no haga trabajo extra"
+	@set -e
+	# Make -n no debe imprimir comandos si no hay trabajo pendiente
+	if [[ -z "$$($(MAKE) -n all 2>/dev/null | sed '/^make\[/d')" ]]; then \
+		echo "[idempotency] OK: no hay trabajo en segunda ejecución"; \
+	else \
+		echo "[idempotency] Fallo: aún hay acciones pendientes en segunda ejecución"; \
+		exit 1; \
+	fi
+
 
 clean:
-	@echo "[clean] Limpiando out/ y dist/..."
+	@echo "[clean] Limpiando $(OUTDIR) y $(DISTDIR)"
 	rm -rf $(OUTDIR) $(DISTDIR)
 	mkdir -p $(OUTDIR) $(DISTDIR)
 	@echo "[clean] OK"
 
+
 help:
 	@echo "Uso: make <target>"
-	@echo "Targets disponibles:"
-	@echo "  all     -> Ejecuta tools, build y test"
-	@echo "  tools   -> Verifica herramientas necesarias"
-	@echo "  build   -> Prepara directorios y artefactos iniciales"
-	@echo "  test    -> Corre pruebas Bats"
-	@echo "  run     -> Ejecuta flujo principal"
-	@echo "  pack    -> Empaqueta código y pruebas"
-	@echo "  clean   -> Limpia directorios out/ y dist/"
-	@echo "  help    -> Muestra esta ayuda"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all                - Ejecuta tools, build y test"
+	@echo "  tools              - Verifica herramientas"
+	@echo "  build              - Venv + deps + caché"
+	@echo "  run                - Ejecuta el servicio en foreground"
+	@echo "  test               - Arranca servicio, corre Bats y guarda evidencias en out/"
+	@echo "  pack               - Crea dist/proyecto-<REL>.tar.gz"
+	@echo "  verify-idempotency - Comprueba que la segunda corrida no hace trabajo"
+	@echo "  clean              - Limpia out/ y dist/"
+	@echo "  help               - Esta ayuda"

--- a/docs/bitacora-sprint-3.md
+++ b/docs/bitacora-sprint-3.md
@@ -1,0 +1,78 @@
+# Bitácora — Sprint 3
+
+## Pruebas bats
+
+### 1) Objetivos
+- Refactor de pruebas: limpieza, nombres claros, helpers reutilizables.
+- Añadir test de **idempotencia**: dos corridas seguidas sin “trabajo extra” (payload estable; contador de métricas aumenta solo lo esperado).
+- Mantener AAA/RGR y evidencias legibles.
+
+### 2) Cambios principales
+
+-`src/service.py`
+  - **Logging** a `out/service.log` (configurable con `LOG_PATH`).
+  - **Nueva métrica global** `http_requests_total` (todas las requests) además de `http_requests_total{path="/health"}`.
+  - **Hook** `@before_request` para contar cada request entrante.
+  - **Concurrencia**: contadores protegidos con `threading.Lock`.
+  - **Robustez**: manejo de errores con `try/except` en `/health` y `/metrics`, con `logging.exception`.
+  - **Sin cambios de contrato**: `/health` sigue respondiendo `{"status":"ok"}` y `/metrics` mantiene `process_uptime_seconds` y el contador de `/health`.
+
+
+
+- `tests/health_metrics.bats`:
+  - Helpers: `curl_json`, `curl_plain`, `metric_value`, `normalize_health_body`, `save_evidence`.
+  - Positivos: `/health` (200/json/ok/latencia), `/metrics` (text/plain + mínimas).
+  - Negativos estables: estructura inválida en `/metrics`, `status` incorrecto en `/health`, detector de latencia.
+  - **Nuevo**: test `idempotencia-health-2x`.
+
+### 3) Idempotencia
+- **Payload**: se enmascara el campo volátil `"time"` y se comparan hashes SHA-256 de los cuerpos normalizados en dos llamadas consecutivas a `/health`.
+- **Métrica**: se lee `http_requests_total{path="/health"}` antes y después; se exige `delta == 2`.
+
+### 4) Evidencias
+Tras ejecutar:
+```bash
+bats tests/health_metrics.bats
+```
+
+Se generan directorios `out/` con:
+
+* `.../idempotencia-health-2x/headers.txt`
+* `.../idempotencia-health-2x/body_excerpt.txt`
+* `.../idempotencia-health-2x/meta.txt`
+
+**Ejemplo de `meta.txt`:**
+
+```
+base_url=http://127.0.0.1:8080
+budget_ms=200
+http_code=200
+time_total_s=0.041,0.039
+content_type=Content-Type: application/json
+```
+
+### 5) Cómo interpretar
+
+* **Idempotente**: si `norm1 == norm2` y el delta del contador es `2`, la operación GET no introduce trabajo extra ni efectos colaterales inesperados.
+* Si falla:
+  * Revisa `headers.txt` y `body_excerpt.txt`.
+  * Verifica que `/metrics` reporte `http_requests_total{path="/health"}`.
+
+### 4) Ejecución rápida
+
+> Requisitos: Python 3, `bats` instalado, y puerto `8080` libre.
+
+**1) Preparar entorno**
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+```
+
+```bash
+# Valores por defecto:
+# BASE_URL=http://127.0.0.1:8080
+# BUDGET_MS=200
+
+bats tests/health_metrics.bats
+```

--- a/docs/bitacora-sprint-3.md
+++ b/docs/bitacora-sprint-3.md
@@ -1,0 +1,58 @@
+# Bitácora — Sprint 3
+
+## Pruebas bats
+
+### 1) Objetivos
+- Refactor de pruebas: limpieza, nombres claros, helpers reutilizables.
+- Añadir test de **idempotencia**: dos corridas seguidas sin “trabajo extra” (payload estable; contador de métricas aumenta solo lo esperado).
+- Mantener AAA/RGR y evidencias legibles.
+
+### 2) Cambios principales
+- `tests/health_metrics.bats`:
+  - Helpers: `curl_json`, `curl_plain`, `metric_value`, `normalize_health_body`, `save_evidence`.
+  - Positivos: `/health` (200/json/ok/latencia), `/metrics` (text/plain + mínimas).
+  - Negativos estables: estructura inválida en `/metrics`, `status` incorrecto en `/health`, detector de latencia.
+  - **Nuevo**: test `idempotencia-health-2x`.
+
+### 3) Idempotencia
+- **Payload**: se enmascara el campo volátil `"time"` y se comparan hashes SHA-256 de los cuerpos normalizados en dos llamadas consecutivas a `/health`.
+- **Métrica**: se lee `http_requests_total{path="/health"}` antes y después; se exige `delta == 2`.
+
+### 4) Evidencias
+Tras ejecutar:
+```bash
+bats tests/health_metrics.bats
+```
+
+Se generan directorios `out/` con:
+
+* `.../idempotencia-health-2x/headers.txt`
+* `.../idempotencia-health-2x/body_excerpt.txt`
+* `.../idempotencia-health-2x/meta.txt`
+
+**Ejemplo de `meta.txt`:**
+
+```
+base_url=http://127.0.0.1:8080
+budget_ms=200
+http_code=200
+time_total_s=0.041,0.039
+content_type=Content-Type: application/json
+```
+
+### 5) Cómo interpretar
+
+* **Idempotente**: si `norm1 == norm2` y el delta del contador es `2`, la operación GET no introduce trabajo extra ni efectos colaterales inesperados.
+* Si falla:
+  * Revisa `headers.txt` y `body_excerpt.txt`.
+  * Verifica que `/metrics` reporte `http_requests_total{path="/health"}`.
+
+### 4) Ejecución rápida
+
+```bash
+# Valores por defecto:
+# BASE_URL=http://127.0.0.1:8080
+# BUDGET_MS=200
+
+bats tests/health_metrics.bats
+```

--- a/src/service.py
+++ b/src/service.py
@@ -2,42 +2,70 @@
 import os
 import time
 import threading
+import logging
 from flask import Flask, jsonify, Response, request
 
 app = Flask(__name__)
 
-PORT = int(os.getenv("PORT", "8080")) 
+# --- Configuración ---
+PORT = int(os.getenv("PORT", "8080"))
 BIND_ADDR = os.getenv("BIND_ADDR", "127.0.0.1")
+LOG_PATH = os.getenv("LOG_PATH", "out/service.log")
 
+# --- Logging básico ---
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+logging.basicConfig(
+    filename=LOG_PATH,
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+# --- Métricas internas ---
 START_TIME = time.time()
 _health_requests = 0
+_total_requests = 0
 _lock = threading.Lock()
 
 def inc_health():
     global _health_requests
     with _lock:
         _health_requests += 1
+        logging.info("/health called (%d total)", _health_requests)
 
-def get_health_requests():
+def inc_total():
+    global _total_requests
     with _lock:
-        return _health_requests
+        _total_requests += 1
 
 def uptime_seconds():
     return max(0.0, time.time() - START_TIME)
 
+@app.before_request
+def before_request():
+    inc_total()
+
 @app.get("/health")
 def health():
-    inc_health()
-    return jsonify(status="ok"), 200, {"Content-Type": "application/json"}
+    try:
+        inc_health()
+        return jsonify(status="ok"), 200, {"Content-Type": "application/json"}
+    except Exception as e:
+        logging.exception("Error en /health: %s", e)
+        return jsonify(status="error", message=str(e)), 500
 
 @app.get("/metrics")
 def metrics():
-    lines = []
-    lines.append(f"process_uptime_seconds {uptime_seconds():.6f}")
-    lines.append(f'http_requests_total{{path="/health"}} {get_health_requests()}')
-    body = "\n".join(lines) + "\n"
-
-    return Response(body, status=200, mimetype="text/plain")
+    try:
+        lines = [
+            f"process_uptime_seconds {uptime_seconds():.6f}",
+            f'http_requests_total{{path="/health"}} {_health_requests}',
+            f"http_requests_total {_total_requests}",
+        ]
+        body = "\n".join(lines) + "\n"
+        return Response(body, status=200, mimetype="text/plain")
+    except Exception as e:
+        logging.exception("Error en /metrics: %s", e)
+        return Response(f"# error: {e}\n", status=500, mimetype="text/plain")
 
 @app.get("/", defaults={"path": ""})
 @app.get("/<path:path>")
@@ -45,4 +73,5 @@ def not_found(path):
     return jsonify(error="not found"), 404, {"Content-Type": "application/json"}
 
 if __name__ == "__main__":
+    logging.info("Servicio iniciado en %s:%s", BIND_ADDR, PORT)
     app.run(host=BIND_ADDR, port=PORT, debug=False, use_reloader=False)

--- a/tests/health_metric.bats
+++ b/tests/health_metric.bats
@@ -66,6 +66,29 @@ get_header() {
   grep -i "^$name:" "$TMP_H" | head -n1 | tr -d '\r'
 }
 
+# metric_value <regex-linea-completa>
+# Devuelve solo el número al final de la línea; si no hay match, imprime vacío.
+metric_value() {
+  local line_regex="$1"
+  # Toma primera coincidencia, corta último campo
+  local line
+  line="$(grep -E "$line_regex" "$TMP_B" | head -n1 || true)"
+  [ -z "$line" ] && { echo ""; return 0; }
+  # último campo (valor)
+  echo "$line" | awk '{print $NF}'
+}
+
+# normalize_health_body: redacción invariante para comparar (enmascara "time")
+normalize_health_body() {
+  # Sustituye el valor del campo "time" por un marcador estable
+  sed -E 's/"time"[[:space:]]*:[[:space:]]*"[^"]*"/"time":"<xxxxx>"/g' "$TMP_B"
+}
+
+# sha256_of_stdin: hash estable sin saltos extra
+sha256_of_stdin() {
+  # shellcheck disable=SC2002
+  cat - | sha256sum | awk '{print $1}'
+}
 
 #
 # --------- CASOS POSITIVOS ---------
@@ -173,4 +196,50 @@ get_header() {
   # Guardamos evidencia básica (no tenemos TMP_H/TMP_B aquí, así que solo meta)
   HTTP_CODE="" TIME_TOTAL_S=""
   save_evidence "health-neg-latency"
+}
+
+# -----------------------
+# Idempotencia
+# -----------------------
+# 1) Dos GET consecutivos a /health no cambian el payload excepto campos volátiles (time).
+# 2) El contador http_requests_total{path="/health"} aumenta en al menos el número de llamadas efectuadas (predecible y sin "trabajo extra" no solicitado).
+
+@test "idempotencia: dos GET /health seguidos, payload estable y diferencia de métricas predecible" {
+  # Arrange: leer contador base
+  read -r _ _ <<<"$(curl_plain /metrics)"
+  local base
+  base="$(metric_value '^http_requests_total\{.*path="/health".*\} [0-9.eE+-]+$')"
+  [ -n "$base" ] || skip "No se pudo leer contador base en /metrics (skip idempotencia)."
+
+  # Act 1: primera llamada a /health
+  read -r code1 t1 <<<"$(curl_json /health)"
+  [ "$code1" -eq 200 ]
+  local norm1
+  norm1="$(normalize_health_body | sha256_of_stdin)"
+
+  # Act 2: segunda llamada a /health
+  read -r code2 t2 <<<"$(curl_json /health)"
+  [ "$code2" -eq 200 ]
+  local norm2
+  norm2="$(normalize_health_body | sha256_of_stdin)"
+
+  # Assert A: payloads normalizados iguales (solo 'time' puede variar)
+  [ "$norm1" = "$norm2" ]
+
+  # Assert B: delta de métrica >= 2 y <= 2 + ALLOW_METRIC_SLACK
+  read -r _ _ <<<"$(curl_plain /metrics)"
+  local after
+  after="$(metric_value '^http_requests_total\{.*path="/health".*\} [0-9.eE+-]+$')"
+  [ -n "$after" ]
+
+  # usamos awk para comparar números con posible parte decimal
+  run awk -v a="$after" -v b="$base" 'BEGIN{
+    delta = a - b
+    exit !(delta == 2)
+  }'
+  [ "$status" -eq 0 ]
+
+  # Evidencia
+  HTTP_CODE=200 TIME_TOTAL_S="$t1,$t2" CONTENT_TYPE="$(get_header Content-Type)"
+  save_evidence "idempotencia-health-2x"
 }

--- a/tests/health_metric.bats
+++ b/tests/health_metric.bats
@@ -71,7 +71,7 @@ get_header() {
 # --------- CASOS POSITIVOS ---------
 #
 
-@test "GET /health -> 200 y Content-Type application/json (contrato mínimo)" {
+@test "health: 200 y Content-Type application/json" {
   # Act
   read -r HTTP_CODE TIME_TOTAL_S <<<"$(curl_json /health)"
   CONTENT_TYPE="$(get_header Content-Type)"
@@ -85,7 +85,7 @@ get_header() {
   save_evidence "health-200"
 }
 
-@test "GET /health -> body con status=\"ok\" y latencia <= BUDGET_MS" {
+@test "health: status=\"ok\" y latencia <= BUDGET_MS" {
   # Act
   read -r HTTP_CODE TIME_TOTAL_S <<<"$(curl_json /health)"
 
@@ -104,7 +104,7 @@ get_header() {
   save_evidence "health-ok-latency"
 }
 
-@test "GET /metrics -> 200, text/plain y métricas mínimas (uptime + requests a /health)" {
+@test "metrics: 200, text/plain y métricas mínimas" {
   # Act
   read -r HTTP_CODE CONTENT_TYPE <<<"$(curl_plain /metrics)"
   # Assert
@@ -123,7 +123,7 @@ get_header() {
 # --------- CASOS NEGATIVOS AMPLIADOS ---------
 #
 
-@test "NEG: /metrics estructura inválida -> si sucede, debe detectarse y reportarse" {
+@test "neg: estructura inválida en metrics -> si aparece, debe detectarse" {
   # Este negativo se ejecuta SOLO si la respuesta realmente está mal formada.
   # Si está bien, hacemos skip (precondición no cumplida) para mantener verde.
   run curl -sS "$BASE_URL/metrics" > "$TMP_B"
@@ -146,7 +146,7 @@ get_header() {
   save_evidence "metrics-neg-structure"
 }
 
-@test "NEG: /health con status distinto de \"ok\" -> si sucede, debe detectarse" {
+@test "neg: health con status distinto a \"ok\" -> si ocurre, detectarlo" {
   # Solo valida si el status devuelto NO es 'ok'. Si es 'ok', skip.
   read -r _ _ <<<"$(curl_json /health)"
   if grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' "$TMP_B"; then
@@ -159,7 +159,7 @@ get_header() {
 
 }
 
-@test "NEG: latencia por encima de BUDGET_MS -> detector debe marcar exceso" {
+@test "neg: detector de latencia (umbral local estricto)" {
   # Simulación controlada: fijamos un umbral estricto local para forzar la condición.
   # Esto valida el detector SIN depender de la latencia real del entorno.
   STRICT_MS=1  # 1 ms, fuerza exceso casi siempre


### PR DESCRIPTION
# PR Final - Sprint 3

## Objetivos
- Refactor de la suite Bats (limpieza, helpers, nombres claros, sin fixtures innecesarios).
- Test de idempotencia sobre GET /health (payload estable y contador coherente).
- Makefile endurecido con cacheo por checksums, artefacto reproducible y verificación de segunda corrida sin trabajo extra.

## Cambios incluidos
- tests/health_metrics.bats (refactorizado)
  - Helpers reutilizables
  - Nombres de pruebas concisos
  - Casos positivos y negativos
  - Prueba de idempotencia con `/health`
- Makefile / Tooling
  - tools (verifica bash, curl, jq, bats, python3).
  - build con cache incremental vía checksums de entradas (código, tests, docs, Makefile, requirements).
  - build con cache incremental vía checksums de entradas (código, tests, docs, Makefile, requirements).
  - verify-idempotency → asegura que una segunda ejecución de all no genera trabajo extra (comprobación real de idempotencia del pipeline).
  - clean y help.
  - pack → tar.gz reproducible (--sort=name, dueños numéricos, SOURCE_DATE_EPOCH, exclusiones de venv/out/dist).
  - Artefactos y logs en out/ y dist/.
- Servicio Flask con endpoints `/health` y `/metrics`
  - Incluir logs de servicio en vivo.
  - Mejorar conteo de peticiones en vivo..

## Resultado esperado
- Suite más legible y mantenible, sin duplicación.
- Pruebas deterministas: negativos con skip si no aplican; detector de latencia sin flakiness.
- Idempotencia garantizada:
  - Payload de `/health` estable (fuera de campos volátiles).
  - Contador de `/metrics` coherente con el número de requests.
- Empaquetado reproducible y build/test sin trabajo adicional en corridas consecutivas.

## Validación local
```bash
# 1) Verificar herramientas, construir y correr pruebas
make all PORT=8080 BUDGET_MS=200

# 2) (Opcional) Ejecutar solo servicio en foreground
make run PORT=8080

# 3) (Opcional) Verificar idempotencia de pipeline
make verify-idempotency

# 4) Empaquetar artefacto reproducible
make pack REL=1.0.0
```

## Checklist

- [x] Refactor de tests/health_metrics.bats con helpers y nombres claros.

- [x] Test de idempotencia (payload + métricas).

- [x] Evidencias legibles en out/.

- [x] Makefile con cache por checksums, empaquetado reproducible y verificación de idempotencia.

- [x] Escritura de logs de servicio Flask en vivo.

- [x] Bitácora Sprint 3 con tiempos/outputs.
